### PR TITLE
long press send key to input \r

### DIFF
--- a/keyboard/CMakeLists.txt
+++ b/keyboard/CMakeLists.txt
@@ -53,6 +53,14 @@ function(add_keyboard_extension keyboard language targets)
 
     add_dependencies(${extension} "${keyboard}Profile")
 
+    # The extension's Swift sources import the KeyboardUI, SwiftUtil, FcitxProtocol
+    # and SwiftFrontend modules. Linking these targets makes CMake add their
+    # swiftmodule files as dependencies of the extension's compile step, so the
+    # extension is recompiled whenever a module interface changes. Otherwise the
+    # extension may be linked against a stale class layout and crash at runtime
+    # (e.g. a ViewModel method dispatched through a shifted vtable slot).
+    target_link_libraries(${extension} KeyboardUI SwiftUtil FcitxProtocol SwiftFrontend)
+
     set_property(GLOBAL APPEND PROPERTY FCITX_RUNTIME_ADDONS ${targets})
 
     copy_to(${keyboard} copy_directory "${PROJECT_SOURCE_DIR}/assets/SwiftTranslations/${keyboard}" "")

--- a/keyboard/KeyboardViewController.swift
+++ b/keyboard/KeyboardViewController.swift
@@ -228,6 +228,10 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
     updateTextIsEmpty()
   }
 
+  public func carriageReturn() {
+    commitString("\r")
+  }
+
   public func setPreedit(_ preedit: String, _ caret: Int) {
     textDocumentProxy.setMarkedText(preedit, selectedRange: NSRange(location: caret, length: 0))
   }

--- a/protocol/FcitxProtocol.swift
+++ b/protocol/FcitxProtocol.swift
@@ -2,6 +2,7 @@
 public protocol FcitxProtocol {
   func keyPressed(_ key: String, _ code: String)
   func forwardKey(_ key: String, _ code: String)
+  func carriageReturn()
   func resetInput()
   func triggerUnicode()
   func triggerQuickPhrase()

--- a/uipanel/Bubble.swift
+++ b/uipanel/Bubble.swift
@@ -162,6 +162,7 @@ struct BubbleView: View {
   let items: [BubbleItem]
   let index: Int
   let highlight: Int
+  let fontSize: CGFloat?
 
   @ViewBuilder
   private func itemView(_ item: BubbleItem, _ h: CGFloat) -> some View {
@@ -173,7 +174,7 @@ struct BubbleView: View {
           .frame(height: h * 0.25)
       }.frame(height: h * 0.3)
     } else {
-      Text(item.label ?? "").font(.system(size: h * 0.25).weight(.light))
+      Text(item.label ?? "").font(.system(size: fontSize ?? h * 0.25).weight(.light))
     }
   }
 
@@ -183,6 +184,7 @@ struct BubbleView: View {
     let position: BubblePosition =
       x - width / 2 - s < 0 ? .left : (x + width / 2 + s > keyboardWidth ? .right : .middle)
     let offsetX = position == .left ? s : (position == .middle ? 0 : -s)
+    let singleTextItem = items.count == 1 && items[0].type == nil
     if let label = label {
       BubbleShape(s: s, height: height, position: position, items: [.text(label)], index: 0)
         .fill(background)
@@ -193,6 +195,19 @@ struct BubbleView: View {
             .offset(y: -h / 4)
         )
         .position(x: x + offsetX, y: y - (h - height) / 2)
+    } else if singleTextItem, let text = items[0].label {
+      // A single text item (e.g. the "return" long-press bubble on a wide key)
+      // is a taller rounded rectangle the same width as the key, with the text
+      // centered in the upper half.
+      RoundedRectangle(cornerRadius: keyCornerRadius)
+        .fill(background)
+        .shadow(color: shadow, radius: shadowRadius)
+        .frame(width: width, height: h)
+        .overlay(
+          Text(text).font(.system(size: fontSize ?? h * 0.25).weight(.light))
+            .offset(y: -h / 4)
+        )
+        .position(x: x, y: y - (h - height) / 2)
     } else {
       let offsetCell = (CGFloat(items.count - 1) / 2 - CGFloat(index)) * cellWidth
       BubbleShape(s: s, height: height, position: position, items: items, index: index)
@@ -206,7 +221,7 @@ struct BubbleView: View {
             ForEach(Array(items.enumerated()), id: \.offset) { i, item in
               itemView(item, h)
                 .frame(width: cellWidth)
-                .condition(i == highlight) {
+                .condition(!singleTextItem && i == highlight) {
                   $0.foregroundColor(.white).background(highlightBackground)
                 }
                 .cornerRadius(keyCornerRadius)

--- a/uipanel/Key.swift
+++ b/uipanel/Key.swift
@@ -278,6 +278,9 @@ struct EnterView: View {
   let highlight: Bool
 
   var body: some View {
+    let returnLabel = NSLocalizedString("return", comment: "")
+    let hasReturnLongPress = !cr && label != returnLabel
+    let returnFontSize = labelFontSize(returnLabel)
     VStack {
       if cr {
         Image(systemName: "return")
@@ -285,8 +288,7 @@ struct EnterView: View {
           .aspectRatio(contentMode: .fit)
           .frame(height: height * 0.4)
       } else {
-        Text(label).font(
-          .system(size: adjustFontSize(label, height * 0.32, (width - columnGap) * 0.95)))
+        Text(label).font(.system(size: labelFontSize(label)))
       }
     }
     .keyProperties(
@@ -306,10 +308,26 @@ struct EnterView: View {
           // it says text is empty but should be sendable.
           vm.resetLayerIfNotLocked()
           client.keyPressed("\r", "Enter")
-        }
+        },
+        // WeChat has send type (\n) but supports newline, so provide a way to input \r.
+        onLongPress: hasReturnLongPress
+          ? { _ in
+            vm.resetLayerIfNotLocked()
+            client.carriageReturn()
+          }
+          : nil
       ),
-      pressedForeground: !cr && !disable && highlight ? getNormalForeground(colorScheme) : nil
+      pressedForeground: !cr && !disable && highlight ? getNormalForeground(colorScheme) : nil,
+      longPressItems: hasReturnLongPress
+        ? [BubbleItem.text(returnLabel)]
+        : [],
+      bubbleBackground: hasReturnLongPress ? getNormalBackground(colorScheme) : nil,
+      bubbleFontSize: hasReturnLongPress ? returnFontSize : nil
     )
+  }
+
+  private func labelFontSize(_ text: String) -> CGFloat {
+    adjustFontSize(text, height * 0.32, (width - columnGap) * 0.95)
   }
 }
 

--- a/uipanel/KeyModifier.swift
+++ b/uipanel/KeyModifier.swift
@@ -29,7 +29,7 @@ private func getNStep(_ start: CGFloat, _ end: CGFloat, _ step: CGFloat) -> Int 
 
 @MainActor
 private func clearBubble() {
-  vm.setBubble(0, 0, 0, 0, .clear, .light, .clear, nil, [], 0, 0)
+  vm.setBubble(0, 0, 0, 0, .clear, .light, .clear, nil, [], 0, 0, nil)
 }
 
 struct KeyModifier: ViewModifier {
@@ -58,6 +58,8 @@ struct KeyModifier: ViewModifier {
   let vMargin: CGFloat
   let radius: CGFloat
   let background: Color
+  let bubbleBackground: Color?
+  let bubbleFontSize: CGFloat?
   let pressedBackground: Color
   let foreground: Color
   let pressedForeground: Color
@@ -112,8 +114,8 @@ struct KeyModifier: ViewModifier {
         bubbleHighlight = longPressIndex
         vm.setBubble(
           bubbleX, bubbleY, bubbleWidth, bubbleHeight,
-          background, colorScheme, shadow, nil, longPressItems, longPressIndex,
-          bubbleHighlight)
+          bubbleBackground ?? background, colorScheme, shadow, nil, longPressItems, longPressIndex,
+          bubbleHighlight, bubbleFontSize)
       } else {
         clearBubble()
         action.onLongPress?(0)
@@ -131,8 +133,8 @@ struct KeyModifier: ViewModifier {
 
     vm.setBubble(
       bubbleX, bubbleY, bubbleWidth, bubbleHeight,
-      background, colorScheme, shadow,
-      bubbleLabel, [], 0, 0)
+      bubbleBackground ?? background, colorScheme, shadow,
+      bubbleLabel, [], 0, 0, bubbleFontSize)
 
     vm.flushOrderedKeyPresses()
     if isDoubleTap(touchTime) {
@@ -169,8 +171,8 @@ struct KeyModifier: ViewModifier {
       if didMoveFarEnough {
         if getSwipeDirection(dx, dy) == .up {
           vm.setBubble(
-            bubbleX, bubbleY, bubbleWidth, bubbleHeight, background, colorScheme,
-            shadow, swipeUpLabel, [], 0, 0)
+            bubbleX, bubbleY, bubbleWidth, bubbleHeight, bubbleBackground ?? background,
+            colorScheme, shadow, swipeUpLabel, [], 0, 0, bubbleFontSize)
         } else {
           clearBubble()
         }
@@ -202,8 +204,8 @@ struct KeyModifier: ViewModifier {
           0, min(bubbleHighlight + delta, longPressItems.count - 1))
         vm.setBubble(
           bubbleX, bubbleY, bubbleWidth, bubbleHeight,
-          background, colorScheme, shadow, nil, longPressItems, longPressIndex,
-          bubbleHighlight)
+          bubbleBackground ?? background, colorScheme, shadow, nil, longPressItems, longPressIndex,
+          bubbleHighlight, bubbleFontSize)
         lastLocation = last + CGFloat(delta) * moveSize
       }
     }
@@ -317,13 +319,15 @@ extension View {
     radius: CGFloat = keyCornerRadius, background: Color, pressedBackground: Color,
     foreground: Color, shadow: Color, action: GestureAction, pressedForeground: Color? = nil,
     pressedView: (any View)? = nil, topRight: String? = nil, bubbleLabel: String? = nil,
-    swipeUpLabel: String? = nil, longPressItems: [BubbleItem]? = nil, longPressIndex: Int? = nil
+    swipeUpLabel: String? = nil, longPressItems: [BubbleItem]? = nil, longPressIndex: Int? = nil,
+    bubbleBackground: Color? = nil, bubbleFontSize: CGFloat? = nil
   ) -> some View {
     self.modifier(
       KeyModifier(
         x: x, y: y, width: width, height: height, hMargin: hMargin, vMargin: vMargin,
         radius: radius,
-        background: background, pressedBackground: pressedBackground,
+        background: background, bubbleBackground: bubbleBackground,
+        bubbleFontSize: bubbleFontSize, pressedBackground: pressedBackground,
         foreground: foreground, pressedForeground: pressedForeground ?? foreground,
         shadow: shadow, action: action, pressedView: pressedView, topRight: topRight,
         bubbleLabel: bubbleLabel, swipeUpLabel: swipeUpLabel,

--- a/uipanel/Keyboard.swift
+++ b/uipanel/Keyboard.swift
@@ -48,6 +48,7 @@ struct KeyboardView: View {
   let bubbleItems: [BubbleItem]
   let bubbleIndex: Int
   let bubbleHighlight: Int
+  let bubbleFontSize: CGFloat?
 
   @State private var defaultRows = [[String: Any]]()
   @State private var shiftRows = [[String: Any]]()
@@ -65,7 +66,8 @@ struct KeyboardView: View {
         BubbleView(
           x: bubbleX, y: bubbleY, width: bubbleWidth, height: bubbleHeight,
           keyboardWidth: width, background: bubbleBackground, shadow: bubbleShadow,
-          label: bubbleLabel, items: bubbleItems, index: bubbleIndex, highlight: bubbleHighlight)
+          label: bubbleLabel, items: bubbleItems, index: bubbleIndex,
+          highlight: bubbleHighlight, fontSize: bubbleFontSize)
       }
     }
     .frame(height: keyboardHeight)

--- a/uipanel/VirtualKeyboard.swift
+++ b/uipanel/VirtualKeyboard.swift
@@ -83,6 +83,7 @@ public class ViewModel: ObservableObject {
   @Published var bubbleItems = [BubbleItem]()
   @Published var bubbleIndex = 0
   @Published var bubbleHighlight = 0
+  @Published var bubbleFontSize: CGFloat? = nil
 
   var hasPreedit: Bool { !preedit.isEmpty || hasClientPreedit }
 
@@ -279,7 +280,7 @@ public class ViewModel: ObservableObject {
   func setBubble(
     _ x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat, _ background: Color,
     _ colorScheme: ColorScheme, _ shadow: Color, _ label: String?, _ items: [BubbleItem],
-    _ index: Int, _ highlight: Int
+    _ index: Int, _ highlight: Int, _ fontSize: CGFloat?
   ) {
     bubbleX = x
     bubbleY = y
@@ -293,6 +294,7 @@ public class ViewModel: ObservableObject {
     bubbleItems = items
     bubbleIndex = index
     bubbleHighlight = highlight
+    bubbleFontSize = fontSize
   }
 
   // Sync config
@@ -364,7 +366,8 @@ public struct VirtualKeyboardView: View {
               bubbleLabel: viewModel.bubbleLabel,
               bubbleItems: viewModel.bubbleItems,
               bubbleIndex: viewModel.bubbleIndex,
-              bubbleHighlight: viewModel.bubbleHighlight
+              bubbleHighlight: viewModel.bubbleHighlight,
+              bubbleFontSize: viewModel.bubbleFontSize
             ).opacity(
               viewModel.mode == .initial || (viewModel.mode == .candidates && !viewModel.expanded)
                 ? 1 : 0)  // Don't recreate KeyboardView when mode changes.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-pressing the Return key now displays a localized return label and inserts a carriage return.
  * Keyboard bubbles support customized text sizes and background colors.

* **UI Improvements**
  * Single-item bubbles now appear as centered, rounded key-sized rectangles.
  * Return-key bubbles have improved sizing, styling, and pressed-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->