### PR TITLE
delete surrounding text

### DIFF
--- a/common/runtime-api.h
+++ b/common/runtime-api.h
@@ -10,8 +10,9 @@ void setLocale(const char *locale);
 
 void focusIn();
 void focusOut();
-void processKey(const char *key, const char *code, const char *surroundingText,
-                unsigned int cursor, unsigned int anchor, bool reset);
+void processKey(const char *key, const char *code, unsigned int modifiers,
+                const char *surroundingText, unsigned int cursor,
+                unsigned int anchor, bool reset);
 void resetInput();
 void triggerUnicode();
 void triggerQuickPhrase();

--- a/common/runtime_keyboard.cpp
+++ b/common/runtime_keyboard.cpp
@@ -40,15 +40,16 @@ void focusOut() {
     dispatcher->schedule([] { frontend->focusOut(); });
 }
 
-void processKey(const char *k, const char *c, const char *text,
-                unsigned int cursor, unsigned int anchor, bool reset) {
+void processKey(const char *k, const char *c, unsigned int modifiers,
+                const char *text, unsigned int cursor, unsigned int anchor,
+                bool reset) {
     std::string key = k, code = c, surroundingText = text;
     dispatcher->schedule([=] {
         updateSurroundingText(surroundingText, cursor, anchor, reset);
-        bool accepted =
-            frontend->keyEvent(fcitx::js_key_to_fcitx_key(
-                                   key, code, 1 << 29 /* KeyState::Virtual */),
-                               false);
+        bool accepted = frontend->keyEvent(
+            fcitx::js_key_to_fcitx_key(
+                key, code, modifiers | 1U << 29 /* KeyState::Virtual */),
+            false);
         if (!accepted) {
             frontend->forwardKey(key, code);
         }

--- a/iosfrontend/iosfrontend.cpp
+++ b/iosfrontend/iosfrontend.cpp
@@ -45,6 +45,10 @@ IosInputContext::IosInputContext(IosFrontend *frontend,
 
 IosInputContext::~IosInputContext() { destroy(); }
 
+void IosInputContext::deleteSurroundingTextImpl(int offset, unsigned int size) {
+    SwiftFrontend::deleteSurroundingTextAsync(offset, size);
+}
+
 void IosInputContext::commitStringImpl(const std::string &text) {
     SwiftFrontend::commitStringAsync(text);
 }

--- a/iosfrontend/iosfrontend.h
+++ b/iosfrontend/iosfrontend.h
@@ -51,7 +51,7 @@ class IosInputContext : public InputContext {
 
     const char *frontend() const override { return "ios"; }
     void commitStringImpl(const std::string &text) override;
-    void deleteSurroundingTextImpl(int offset, unsigned int size) override {}
+    void deleteSurroundingTextImpl(int offset, unsigned int size) override;
     void forwardKeyImpl(const ForwardKeyEvent &key) override {}
     void updatePreeditImpl() override;
     void setSurroundingText(const std::string &text, unsigned int cursor,

--- a/iosfrontend/iosfrontend.swift
+++ b/iosfrontend/iosfrontend.swift
@@ -15,6 +15,12 @@ public func commitStringAsync(_ commit: String) {
   }
 }
 
+public func deleteSurroundingTextAsync(_ offset: Int, _ size: Int) {
+  DispatchQueue.main.async {
+    client.deleteSurroundingText(offset, size)
+  }
+}
+
 public func setPreeditAsync(_ preedit: String, _ cursor: Int) {
   DispatchQueue.main.async {
     client.setPreedit(preedit, cursor)

--- a/keyboard/KeyboardViewController.swift
+++ b/keyboard/KeyboardViewController.swift
@@ -39,6 +39,11 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
     let anchor: UInt32
   }
 
+  private struct SurroundingTextPosition {
+    let utf16Offset: Int
+    let characterOffset: Int
+  }
+
   private static let documentPollingInterval: TimeInterval = 0.2
 
   nonisolated(unsafe) var id: UInt64 = 0
@@ -92,6 +97,33 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         anchor: anchor),
       shouldReset
     )
+  }
+
+  private func position(in text: String, atUnicodeScalarOffset target: Int)
+    -> SurroundingTextPosition?
+  {
+    guard target >= 0 else { return nil }
+    if target == 0 {
+      return SurroundingTextPosition(utf16Offset: 0, characterOffset: 0)
+    }
+
+    var unicodeScalarOffset = 0
+    var utf16Offset = 0
+    var characterOffset = 0
+    for character in text {
+      let character = String(character)
+      unicodeScalarOffset += character.unicodeScalars.count
+      utf16Offset += character.utf16.count
+      characterOffset += 1
+      if unicodeScalarOffset == target {
+        return SurroundingTextPosition(
+          utf16Offset: utf16Offset, characterOffset: characterOffset)
+      }
+      if unicodeScalarOffset > target {
+        return nil
+      }
+    }
+    return nil
   }
 
   // Poll is needed because selectionDidChange is never called even for a standard TextField.
@@ -238,10 +270,11 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
     updateTextIsEmpty()
   }
 
-  public func keyPressed(_ key: String, _ code: String) {
+  public func keyPressed(_ key: String, _ code: String, _ modifiers: UInt32 = 0) {
     let (surroundingText, shouldReset) = surroundingTextForInputEvent()
-    processKey(
-      key, code, surroundingText.text, surroundingText.cursor, surroundingText.anchor, shouldReset)
+    Fcitx.processKey(
+      key, code, modifiers, surroundingText.text, surroundingText.cursor, surroundingText.anchor,
+      shouldReset)
   }
 
   public func forwardKey(_ key: String, _ code: String) {
@@ -320,6 +353,49 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
 
   public func commitString(_ commit: String) {
     textDocumentProxy.insertText(commit)
+    documentState = currentDocumentState()
+    updateTextIsEmpty()
+  }
+
+  public func deleteSurroundingText(_ offset: Int, _ size: Int) {
+    guard size > 0 else { return }
+
+    let state = currentDocumentState()
+    let before = state.contextBeforeInput ?? ""
+    let selected = state.selectedText ?? ""
+    let text = before + selected + (state.contextAfterInput ?? "")
+    let anchor = before.unicodeScalars.count
+    let cursor = anchor + selected.unicodeScalars.count
+    let start = cursor + offset
+    let end = start + size
+    guard
+      start >= 0,
+      end > start,
+      let startPosition = position(in: text, atUnicodeScalarOffset: start),
+      let endPosition = position(in: text, atUnicodeScalarOffset: end),
+      let cursorPosition = position(in: text, atUnicodeScalarOffset: cursor),
+      let anchorPosition = position(in: text, atUnicodeScalarOffset: anchor)
+    else {
+      return
+    }
+
+    var deletionCount = endPosition.characterOffset - startPosition.characterOffset
+    if selected.isEmpty {
+      textDocumentProxy.adjustTextPosition(
+        byCharacterOffset: endPosition.utf16Offset - cursorPosition.utf16Offset)
+    } else {
+      // UITextDocumentProxy can't set an arbitrary selection. We can still delete a range that
+      // contains the current selection by deleting the selection first, then its two sides.
+      guard start <= anchor, end >= cursor else { return }
+      textDocumentProxy.deleteBackward()
+      deletionCount -= cursorPosition.characterOffset - anchorPosition.characterOffset
+      textDocumentProxy.adjustTextPosition(
+        byCharacterOffset: endPosition.utf16Offset - cursorPosition.utf16Offset)
+    }
+
+    for _ in 0..<deletionCount {
+      textDocumentProxy.deleteBackward()
+    }
     documentState = currentDocumentState()
     updateTextIsEmpty()
   }

--- a/protocol/FcitxProtocol.swift
+++ b/protocol/FcitxProtocol.swift
@@ -1,12 +1,13 @@
 @MainActor
 public protocol FcitxProtocol {
-  func keyPressed(_ key: String, _ code: String)
+  func keyPressed(_ key: String, _ code: String, _ modifiers: UInt32)
   func forwardKey(_ key: String, _ code: String)
   func carriageReturn()
   func resetInput()
   func triggerUnicode()
   func triggerQuickPhrase()
   func commitString(_ string: String)
+  func deleteSurroundingText(_ offset: Int, _ size: Int)
   func setPreedit(_ preedit: String, _ cursor: Int)
   func cut()
   func copy()
@@ -16,4 +17,10 @@ public protocol FcitxProtocol {
   func dismissKeyboard()
   func slideBackspace(_ step: Int)
   func syncConfig()
+}
+
+extension FcitxProtocol {
+  public func keyPressed(_ key: String, _ code: String) {
+    keyPressed(key, code, 0)
+  }
 }


### PR DESCRIPTION
modifiers support is added for ease of test on mozc, so that when applying this patch, globe key can trigger it delete surrounding text.
```patch
diff --git a/keyboard/KeyboardViewController.swift b/keyboard/KeyboardViewController.swift
index 93bf6e4..21b85c0 100644
--- a/keyboard/KeyboardViewController.swift
+++ b/keyboard/KeyboardViewController.swift
@@ -440,7 +440,8 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   }
 
   public func globe() {
-    Fcitx.toggle()
+    let ctrlModifier: UInt32 = 1 << 2
+    keyPressed("", "Backspace", ctrlModifier)
   }
 
   public func setCurrentInputMethod(_ inputMethod: String) {
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing keyboard modifier information with key events.
  * Added iOS support for deleting text surrounding the cursor or selection.
  * Improved text-position handling for accurate deletion across Unicode characters.
* **Bug Fixes**
  * Unaccepted key events continue to be forwarded correctly while preserving modifier state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->