### PR TITLE
multi InputContext support

### DIFF
--- a/common/runtime-api.h
+++ b/common/runtime-api.h
@@ -8,14 +8,16 @@ void startKeyboardFcitx(const char *appBundlePath, const char *xdgDataDirs,
                         const char *appGroupPath);
 void setLocale(const char *locale);
 
-void focusIn();
-void focusOut();
-void processKey(const char *key, const char *code, unsigned int modifiers,
+void focusIn(const char *program, const char *documentIdentifier);
+void focusOut(const char *program, const char *documentIdentifier);
+void destroyInputContext(const char *program);
+void processKey(const char *program, const char *documentIdentifier,
+                const char *key, const char *code, unsigned int modifiers,
                 const char *surroundingText, unsigned int cursor,
                 unsigned int anchor, bool reset);
-void resetInput();
-void triggerUnicode();
-void triggerQuickPhrase();
+void resetInput(const char *program, const char *documentIdentifier);
+void triggerUnicode(const char *program, const char *documentIdentifier);
+void triggerQuickPhrase(const char *program, const char *documentIdentifier);
 void reload();
 void toggle();
 

--- a/common/runtime_keyboard.cpp
+++ b/common/runtime_keyboard.cpp
@@ -11,14 +11,6 @@
 
 namespace {
 fcitx::IosFrontend *frontend;
-
-void updateSurroundingText(const std::string &text, unsigned int cursor,
-                           unsigned int anchor, bool reset) {
-    if (reset) {
-        frontend->resetInput();
-    }
-    frontend->setSurroundingText(text, cursor, anchor);
-}
 } // namespace
 
 void startKeyboardFcitx(const char *appBundlePath, const char *xdgDataDirs,
@@ -32,41 +24,54 @@ void startKeyboardFcitx(const char *appBundlePath, const char *xdgDataDirs,
         dynamic_cast<fcitx::IosFrontend *>(addonMgr.addon("iosfrontend"));
 }
 
-void focusIn() {
-    dispatcher->schedule([] { frontend->focusIn(); });
+void focusIn(const char *p, const char *d) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule(
+        [=] { frontend->focusIn(program, documentIdentifier); });
 }
 
-void focusOut() {
-    dispatcher->schedule([] { frontend->focusOut(); });
+void focusOut(const char *p, const char *d) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule(
+        [=] { frontend->focusOut(program, documentIdentifier); });
 }
 
-void processKey(const char *k, const char *c, unsigned int modifiers,
-                const char *text, unsigned int cursor, unsigned int anchor,
-                bool reset) {
-    std::string key = k, code = c, surroundingText = text;
+void destroyInputContext(const char *p) {
+    std::string program = p;
+    dispatcher->schedule([=] { frontend->destroyInputContext(program); });
+}
+
+void processKey(const char *p, const char *d, const char *k, const char *c,
+                unsigned int modifiers, const char *text, unsigned int cursor,
+                unsigned int anchor, bool reset) {
+    std::string program = p, documentIdentifier = d, key = k, code = c,
+                surroundingText = text;
     dispatcher->schedule([=] {
-        updateSurroundingText(surroundingText, cursor, anchor, reset);
         bool accepted = frontend->keyEvent(
+            program, documentIdentifier,
             fcitx::js_key_to_fcitx_key(
                 key, code, modifiers | 1U << 29 /* KeyState::Virtual */),
-            false);
+            false, surroundingText, cursor, anchor, reset);
         if (!accepted) {
-            frontend->forwardKey(key, code);
+            frontend->forwardKey(program, documentIdentifier, key, code);
         }
     });
 }
 
-void resetInput() {
-    dispatcher->schedule([] { frontend->resetInput(); });
+void resetInput(const char *p, const char *d) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule(
+        [=] { frontend->resetInput(program, documentIdentifier); });
 }
 
-void triggerUnicode() {
-    dispatcher->schedule([] {
+void triggerUnicode(const char *p, const char *d) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule([=] {
         auto *unicode = instance->addonManager().addon("unicode");
         if (!unicode) {
             return;
         }
-        auto *ic = instance->mostRecentInputContext();
+        auto *ic = frontend->inputContext(program, documentIdentifier);
         if (!ic) {
             return;
         }
@@ -74,13 +79,14 @@ void triggerUnicode() {
     });
 }
 
-void triggerQuickPhrase() {
-    dispatcher->schedule([] {
+void triggerQuickPhrase(const char *p, const char *d) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule([=] {
         auto *quickphrase = instance->addonManager().addon("quickphrase");
         if (!quickphrase) {
             return;
         }
-        auto *ic = instance->mostRecentInputContext();
+        auto *ic = frontend->inputContext(program, documentIdentifier);
         if (!ic) {
             return;
         }

--- a/iosfrontend/iosfrontend.cpp
+++ b/iosfrontend/iosfrontend.cpp
@@ -1,62 +1,147 @@
 #include "iosfrontend.h"
 #include "iosfrontend-swift.h"
 
+#include <atomic>
+
 namespace fcitx {
+namespace {
+std::atomic_size_t liveInputContextCount = 0;
+}
 
 IosFrontend::IosFrontend(Instance *instance)
     : instance_(instance), focusGroup_("ios", instance->inputContextManager()) {
-    createInputContext();
 }
 
-void IosFrontend::createInputContext() {
-    ic_ = new IosInputContext(this, instance_->inputContextManager());
-    ic_->setFocusGroup(&focusGroup_);
+IosInputContext *
+IosFrontend::findInputContext(const std::string &program,
+                              const std::string &documentIdentifier) const {
+    auto iter = inputContexts_.find(program);
+    if (iter == inputContexts_.end() ||
+        iter->second->documentIdentifier() != documentIdentifier) {
+        return nullptr;
+    }
+    return iter->second;
 }
 
-bool IosFrontend::keyEvent(const Key &key, bool isRelease) {
-    KeyEvent event(ic_, key, isRelease);
-    ic_->keyEvent(event);
+IosInputContext &
+IosFrontend::ensureInputContext(const std::string &program,
+                                const std::string &documentIdentifier) {
+    auto iter = inputContexts_.find(program);
+    if (iter != inputContexts_.end()) {
+        if (iter->second->documentIdentifier() == documentIdentifier) {
+            return *iter->second;
+        }
+        destroyInputContext(iter->second);
+    }
+
+    auto *ic = new IosInputContext(this, instance_->inputContextManager(),
+                                   program, documentIdentifier);
+    ic->setFocusGroup(&focusGroup_);
+    inputContexts_[program] = ic;
+    return *ic;
+}
+
+void IosFrontend::destroyInputContext(IosInputContext *ic) {
+    if (ic->hasFocus()) {
+        ic->focusOut();
+        focusGroup_.setFocusedInputContext(nullptr);
+    }
+    inputContexts_.erase(ic->program());
+    delete ic;
+}
+
+void IosFrontend::destroyInputContext(const std::string &program) {
+    auto iter = inputContexts_.find(program);
+    if (iter != inputContexts_.end()) {
+        destroyInputContext(iter->second);
+    }
+}
+
+bool IosFrontend::keyEvent(const std::string &program,
+                           const std::string &documentIdentifier,
+                           const Key &key, bool isRelease,
+                           const std::string &text, unsigned int cursor,
+                           unsigned int anchor, bool reset) {
+    auto &ic = ensureInputContext(program, documentIdentifier);
+    ic.focusIn();
+    if (reset) {
+        ic.reset();
+    }
+    ic.setSurroundingText(text, cursor, anchor);
+    KeyEvent event(&ic, key, isRelease);
+    ic.keyEvent(event);
     return event.accepted();
 }
 
-void IosFrontend::forwardKey(const std::string &key, const std::string &code) {
-    SwiftFrontend::forwardKeyAsync(key, code);
+void IosFrontend::forwardKey(const std::string &program,
+                             const std::string &documentIdentifier,
+                             const std::string &key, const std::string &code) {
+    SwiftFrontend::forwardKeyAsync(program, documentIdentifier, key, code);
 }
 
-void IosFrontend::focusIn() { ic_->focusIn(); }
+void IosFrontend::focusIn(const std::string &program,
+                          const std::string &documentIdentifier) {
+    ensureInputContext(program, documentIdentifier).focusIn();
+}
 
-void IosFrontend::focusOut() { ic_->focusOut(); }
+void IosFrontend::focusOut(const std::string &program,
+                           const std::string &documentIdentifier) {
+    if (auto *ic = findInputContext(program, documentIdentifier);
+        ic && ic->hasFocus()) {
+        ic->focusOut();
+    }
+}
 
-void IosFrontend::resetInput() { ic_->reset(); }
+void IosFrontend::resetInput(const std::string &program,
+                             const std::string &documentIdentifier) {
+    if (auto *ic = findInputContext(program, documentIdentifier)) {
+        ic->reset();
+    }
+}
 
-void IosFrontend::setSurroundingText(const std::string &text,
-                                     unsigned int cursor, unsigned int anchor) {
-    ic_->setSurroundingText(text, cursor, anchor);
+InputContext *IosFrontend::inputContext(const std::string &program,
+                                        const std::string &documentIdentifier) {
+    return findInputContext(program, documentIdentifier);
 }
 
 IosInputContext::IosInputContext(IosFrontend *frontend,
-                                 InputContextManager &inputContextManager)
-    : InputContext(inputContextManager, ""), frontend_(frontend) {
+                                 InputContextManager &inputContextManager,
+                                 const std::string &program,
+                                 const std::string &documentIdentifier)
+    : InputContext(inputContextManager, program), frontend_(frontend),
+      documentIdentifier_(documentIdentifier) {
     CapabilityFlags flags = CapabilityFlag::Preedit;
     flags |= CapabilityFlag::SurroundingText;
     setCapabilityFlags(flags);
     created();
+    auto count = ++liveInputContextCount;
+    FCITX_INFO() << "Create IC program=" << program
+                 << " document=" << documentIdentifier
+                 << " liveInputContexts=" << count;
 }
 
-IosInputContext::~IosInputContext() { destroy(); }
+IosInputContext::~IosInputContext() {
+    destroy();
+    auto count = --liveInputContextCount;
+    FCITX_INFO() << "Destroy IC program=" << program()
+                 << " document=" << documentIdentifier_
+                 << " liveInputContexts=" << count;
+}
 
 void IosInputContext::deleteSurroundingTextImpl(int offset, unsigned int size) {
-    SwiftFrontend::deleteSurroundingTextAsync(offset, size);
+    SwiftFrontend::deleteSurroundingTextAsync(program(), documentIdentifier_,
+                                              offset, size);
 }
 
 void IosInputContext::commitStringImpl(const std::string &text) {
-    SwiftFrontend::commitStringAsync(text);
+    SwiftFrontend::commitStringAsync(program(), documentIdentifier_, text);
 }
 
 void IosInputContext::updatePreeditImpl() {
     auto preedit =
         frontend_->instance()->outputFilter(this, inputPanel().clientPreedit());
-    SwiftFrontend::setPreeditAsync(preedit.toString(), preedit.cursor());
+    SwiftFrontend::setPreeditAsync(program(), documentIdentifier_,
+                                   preedit.toString(), preedit.cursor());
 }
 
 void IosInputContext::setSurroundingText(const std::string &text,

--- a/iosfrontend/iosfrontend.cpp
+++ b/iosfrontend/iosfrontend.cpp
@@ -27,17 +27,27 @@ IosInputContext &
 IosFrontend::ensureInputContext(const std::string &program,
                                 const std::string &documentIdentifier) {
     auto iter = inputContexts_.find(program);
+    IosInputContext *oldIC = nullptr;
     if (iter != inputContexts_.end()) {
         if (iter->second->documentIdentifier() == documentIdentifier) {
             return *iter->second;
         }
-        destroyInputContext(iter->second);
+        oldIC = iter->second;
+        if (oldIC->hasFocus()) {
+            oldIC->focusOut();
+            focusGroup_.setFocusedInputContext(nullptr);
+        }
     }
 
     auto *ic = new IosInputContext(this, instance_->inputContextManager(),
                                    program, documentIdentifier);
     ic->setFocusGroup(&focusGroup_);
     inputContexts_[program] = ic;
+    if (oldIC) {
+        // Keep the old context alive until the new one is registered so fcitx
+        // can propagate per-program input state to the new context.
+        destroyInputContext(oldIC);
+    }
     return *ic;
 }
 
@@ -46,7 +56,10 @@ void IosFrontend::destroyInputContext(IosInputContext *ic) {
         ic->focusOut();
         focusGroup_.setFocusedInputContext(nullptr);
     }
-    inputContexts_.erase(ic->program());
+    auto iter = inputContexts_.find(ic->program());
+    if (iter != inputContexts_.end() && iter->second == ic) {
+        inputContexts_.erase(iter);
+    }
     delete ic;
 }
 

--- a/iosfrontend/iosfrontend.h
+++ b/iosfrontend/iosfrontend.h
@@ -7,6 +7,9 @@
 #include <fcitx/focusgroup.h>
 #include <fcitx/instance.h>
 
+#include <string>
+#include <unordered_map>
+
 namespace fcitx {
 
 class IosInputContext;
@@ -21,19 +24,34 @@ class IosFrontend : public AddonInstance {
     const Configuration *getConfig() const override { return nullptr; }
     void setConfig(const RawConfig &config) override {}
 
-    void createInputContext();
-    bool keyEvent(const Key &key, bool isRelease);
-    void forwardKey(const std::string &key, const std::string &code);
-    void focusIn();
-    void focusOut();
-    void resetInput();
-    void setSurroundingText(const std::string &text, unsigned int cursor,
-                            unsigned int anchor);
+    bool keyEvent(const std::string &program,
+                  const std::string &documentIdentifier, const Key &key,
+                  bool isRelease, const std::string &text, unsigned int cursor,
+                  unsigned int anchor, bool reset);
+    void forwardKey(const std::string &program,
+                    const std::string &documentIdentifier,
+                    const std::string &key, const std::string &code);
+    void focusIn(const std::string &program,
+                 const std::string &documentIdentifier);
+    void focusOut(const std::string &program,
+                  const std::string &documentIdentifier);
+    void destroyInputContext(const std::string &program);
+    void resetInput(const std::string &program,
+                    const std::string &documentIdentifier);
+    InputContext *inputContext(const std::string &program,
+                               const std::string &documentIdentifier);
 
   private:
     Instance *instance_;
     FocusGroup focusGroup_;
-    IosInputContext *ic_;
+    std::unordered_map<std::string, IosInputContext *> inputContexts_;
+
+    IosInputContext *
+    findInputContext(const std::string &program,
+                     const std::string &documentIdentifier) const;
+    IosInputContext &ensureInputContext(const std::string &program,
+                                        const std::string &documentIdentifier);
+    void destroyInputContext(IosInputContext *ic);
 };
 
 class IosFrontendFactory : public AddonFactory {
@@ -46,7 +64,9 @@ class IosFrontendFactory : public AddonFactory {
 class IosInputContext : public InputContext {
   public:
     IosInputContext(IosFrontend *frontend,
-                    InputContextManager &inputContextManager);
+                    InputContextManager &inputContextManager,
+                    const std::string &program,
+                    const std::string &documentIdentifier);
     ~IosInputContext();
 
     const char *frontend() const override { return "ios"; }
@@ -56,8 +76,12 @@ class IosInputContext : public InputContext {
     void updatePreeditImpl() override;
     void setSurroundingText(const std::string &text, unsigned int cursor,
                             unsigned int anchor);
+    const std::string &documentIdentifier() const {
+        return documentIdentifier_;
+    }
 
   private:
     IosFrontend *frontend_;
+    std::string documentIdentifier_;
 };
 } // namespace fcitx

--- a/iosfrontend/iosfrontend.swift
+++ b/iosfrontend/iosfrontend.swift
@@ -2,33 +2,45 @@ import FcitxProtocol
 import Foundation
 
 @MainActor
-private var client: FcitxProtocol!
+private weak var client: FcitxProtocol?
 
 @MainActor
 public func setClient(_ cli: FcitxProtocol) {
   client = cli
 }
 
-public func commitStringAsync(_ commit: String) {
+public func commitStringAsync(
+  _ program: String, _ documentIdentifier: String, _ commit: String
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     client.commitString(commit)
   }
 }
 
-public func deleteSurroundingTextAsync(_ offset: Int, _ size: Int) {
+public func deleteSurroundingTextAsync(
+  _ program: String, _ documentIdentifier: String, _ offset: Int, _ size: Int
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     client.deleteSurroundingText(offset, size)
   }
 }
 
-public func setPreeditAsync(_ preedit: String, _ cursor: Int) {
+public func setPreeditAsync(
+  _ program: String, _ documentIdentifier: String, _ preedit: String, _ cursor: Int
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     client.setPreedit(preedit, cursor)
   }
 }
 
-public func forwardKeyAsync(_ key: String, _ code: String) {
+public func forwardKeyAsync(
+  _ program: String, _ documentIdentifier: String, _ key: String, _ code: String
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     client.forwardKey(key, code)
   }
 }

--- a/keyboard/KeyboardViewController.swift
+++ b/keyboard/KeyboardViewController.swift
@@ -96,9 +96,14 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   private func surroundingTextForInputEvent() -> (SurroundingText, String, Bool) {
     let currentDocumentState = currentDocumentState()
     let shouldReset = currentDocumentState != documentState
+    let documentChanged = currentDocumentState.identifier != documentState?.identifier
     documentState = currentDocumentState
-    if shouldReset {
+    if documentChanged {
+      vm.clearInputPanel()
+    } else if shouldReset {
       FCITX_INFO("Document state changed \(self.id)")
+    }
+    if shouldReset {
       updateTextIsEmpty()
     }
 
@@ -156,6 +161,7 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         // Known issue: if 2 rows are identical, changing between with caret at same position won't call reset.
         guard currentDocumentState != self.documentState else { return }
         if currentDocumentState.identifier != self.documentState?.identifier {
+          vm.clearInputPanel()
           Fcitx.focusIn(self.program, currentDocumentState.identifier)
         } else {
           FCITX_INFO("Document state changed \(self.id)")
@@ -261,6 +267,7 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
     } else {
       acceptsFcitxCommands = true
       vm.setDisplayMode(.initial)
+      vm.clearInputPanel()
       Fcitx.focusIn(program, currentDocumentIdentifier())
       self.resetInput()  // Avoid old context carried over.
     }

--- a/keyboard/KeyboardViewController.swift
+++ b/keyboard/KeyboardViewController.swift
@@ -26,8 +26,8 @@ private func syncLocale() -> String {
 class KeyboardViewController: UIInputViewController, FcitxProtocol {
   private struct DocumentState: Equatable {
     // Changing focus between TextFields on the same app screen may not call keyboard's viewWillAppear.
-    // Fact not related to our use case: changing back a previously focused TextField won't preserve documentIdentifier.
-    let identifier: String?
+    // iOS issues a new documentIdentifier even when focus returns to a previously focused TextField.
+    let identifier: String
     let contextBeforeInput: String?
     let selectedText: String?
     let contextAfterInput: String?
@@ -45,27 +45,42 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   }
 
   private static let documentPollingInterval: TimeInterval = 0.2
+  nonisolated(unsafe) private static var liveControllerCount = 0
 
   nonisolated(unsafe) var id: UInt64 = 0
+  nonisolated(unsafe) private var countedAsLive = false
   var hostingController: UIHostingController<VirtualKeyboardView>!
   var removedBySlide = ""
+  // Reject queued C++ callbacks after the controller stops accepting input. Its program and
+  // documentIdentifier may remain unchanged between viewWillDisappear and deinit. This also stays
+  // false for the config-sync document, where Fcitx must not modify the proxy.
+  private var acceptsFcitxCommands = false
   private var documentState: DocumentState?
   private var documentPollingTimer: Timer?
   static let keyboard = Bundle.main.bundleURL.deletingPathExtension().lastPathComponent
   static private var clipboardText = ""
   static private var firstLoad = true
 
+  private var program: String {
+    String(id)
+  }
+
+  public func isCurrentDocument(_ program: String, _ documentIdentifier: String) -> Bool {
+    acceptsFcitxCommands && self.program == program
+      && currentDocumentIdentifier() == documentIdentifier
+  }
+
   // UIKit may temporarily return nil while switching between text inputs, even though Swift
   // imports documentIdentifier as a non-optional UUID. Read it through Objective-C to avoid a
   // trap in UUID._unconditionallyBridgeFromObjectiveC during that transition.
-  private func currentDocumentIdentifier() -> String? {
+  private func currentDocumentIdentifier() -> String {
     let selector = NSSelectorFromString("documentIdentifier")
     guard
       let proxy = textDocumentProxy as? NSObject,
       proxy.responds(to: selector),
       let identifier = proxy.perform(selector)?.takeUnretainedValue() as? NSUUID
     else {
-      return nil
+      return ""
     }
     return identifier.uuidString
   }
@@ -78,7 +93,7 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
       contextAfterInput: textDocumentProxy.documentContextAfterInput)
   }
 
-  private func surroundingTextForInputEvent() -> (SurroundingText, Bool) {
+  private func surroundingTextForInputEvent() -> (SurroundingText, String, Bool) {
     let currentDocumentState = currentDocumentState()
     let shouldReset = currentDocumentState != documentState
     documentState = currentDocumentState
@@ -95,6 +110,7 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         text: before + selected + (currentDocumentState.contextAfterInput ?? ""),
         cursor: anchor + UInt32(selected.unicodeScalars.count),
         anchor: anchor),
+      currentDocumentState.identifier,
       shouldReset
     )
   }
@@ -137,10 +153,14 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         guard let self else { return }
         let currentDocumentState = self.currentDocumentState()
         defer { self.documentState = currentDocumentState }
-        // Known issue: if 2 rows are identical, changing between
+        // Known issue: if 2 rows are identical, changing between with caret at same position won't call reset.
         guard currentDocumentState != self.documentState else { return }
-        FCITX_INFO("Document state changed \(self.id)")
-        self.resetInput()
+        if currentDocumentState.identifier != self.documentState?.identifier {
+          Fcitx.focusIn(self.program, currentDocumentState.identifier)
+        } else {
+          FCITX_INFO("Document state changed \(self.id)")
+          self.resetInput()
+        }
         self.updateTextIsEmpty()
       }
     }
@@ -170,7 +190,9 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
 
   override func viewDidLoad() {
     id = UInt64(Int(bitPattern: Unmanaged.passUnretained(self).toOpaque()))
-    FCITX_INFO("viewDidLoad \(self.id)")
+    countedAsLive = true
+    Self.liveControllerCount += 1
+    FCITX_INFO("viewDidLoad \(self.id) liveControllers=\(Self.liveControllerCount)")
     super.viewDidLoad()
     if KeyboardViewController.firstLoad {
       KeyboardViewController.firstLoad = false
@@ -195,6 +217,7 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
 
   override func viewWillAppear(_ animated: Bool) {
     FCITX_INFO("viewWillAppear \(self.id)")
+    acceptsFcitxCommands = false
     SwiftFrontend.setClient(self)
     KeyboardUI.setClient(self)
 
@@ -219,14 +242,15 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         reload()
       }
     }
-    self.resetInput()  // Avoid old context carried over.
-
     if !appGroupAvailable,
       let textBefore = textDocumentProxy.documentContextBeforeInput,
       textBefore.hasPrefix(syncConfigMagicText)
     {
       // In sync config context.
-      focusOut()  // Avoid reload() to set .initial display mode.
+      // Focusing this document makes FocusGroup drop any previously active context; focusing it
+      // out below then leaves the group without an active context during config sync.
+      Fcitx.focusIn(program, currentDocumentIdentifier())
+      Fcitx.focusOut(program, currentDocumentIdentifier())
       textDocumentProxy.insertText(hasFullAccess ? syncConfigFullAccess : syncConfigNoFullAccess)
       if hasFullAccess {
         vm.keyboardDisplayName = getKeyboardDisplayName(Bundle.main.bundleURL)
@@ -235,8 +259,10 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
         vm.setDisplayMode(.syncPending)
       }
     } else {
+      acceptsFcitxCommands = true
       vm.setDisplayMode(.initial)
-      focusIn()
+      Fcitx.focusIn(program, currentDocumentIdentifier())
+      self.resetInput()  // Avoid old context carried over.
     }
     startDocumentPolling()
   }
@@ -244,16 +270,20 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   override func viewWillDisappear(_ animated: Bool) {
     FCITX_INFO("viewWillDisappear \(self.id)")
     super.viewWillDisappear(animated)
+    acceptsFcitxCommands = false
+    Fcitx.focusOut(program, currentDocumentIdentifier())
     stopDocumentPolling()
-    // Old viewWillDisappear may be called after new viewWillAppear (if switching apps), and viewWillDisappear may be called twice.
-    // Don't call focusOut as we use a single InputContext.
     hostingController.willMove(toParent: nil)
     hostingController.view.removeFromSuperview()
     hostingController.removeFromParent()
   }
 
   deinit {
-    FCITX_INFO("deinit \(self.id)")
+    if countedAsLive {
+      Fcitx.destroyInputContext(String(id))
+      Self.liveControllerCount -= 1
+      FCITX_INFO("deinit \(self.id) liveControllers=\(Self.liveControllerCount)")
+    }
   }
 
   override func viewWillLayoutSubviews() {
@@ -271,13 +301,15 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   }
 
   public func keyPressed(_ key: String, _ code: String, _ modifiers: UInt32 = 0) {
-    let (surroundingText, shouldReset) = surroundingTextForInputEvent()
+    let (surroundingText, documentIdentifier, shouldReset) = surroundingTextForInputEvent()
     Fcitx.processKey(
-      key, code, modifiers, surroundingText.text, surroundingText.cursor, surroundingText.anchor,
-      shouldReset)
+      program, documentIdentifier, key, code, modifiers, surroundingText.text,
+      surroundingText.cursor,
+      surroundingText.anchor, shouldReset)
   }
 
   public func forwardKey(_ key: String, _ code: String) {
+    let documentIdentifier = currentDocumentIdentifier()
     // documentContextBeforeInput could be all text or text in current line before cursor.
     // In the latter case, it will be '\n' if caret is at the beginning of a non-first line.
     switch code {
@@ -286,10 +318,12 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
       let step = firstLine(textDocumentProxy.documentContextAfterInput ?? "").utf16.count
       textDocumentProxy.adjustTextPosition(byCharacterOffset: step)
       DispatchQueue.main.async {
+        guard self.currentDocumentIdentifier() == documentIdentifier else { return }
         // Move to the start of next line if exists.
         self.textDocumentProxy.adjustTextPosition(byCharacterOffset: 1)
         // Must have a delay, otherwise nextLineLength is always 0.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          guard self.currentDocumentIdentifier() == documentIdentifier else { return }
           let textAfter = self.textDocumentProxy.documentContextAfterInput ?? ""
           let column = min(offset, firstLine(textAfter).count)
           self.textDocumentProxy.adjustTextPosition(
@@ -309,10 +343,12 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
       let offset = textBefore.count
       textDocumentProxy.adjustTextPosition(byCharacterOffset: -textBefore.utf16.count)
       DispatchQueue.main.async {
+        guard self.currentDocumentIdentifier() == documentIdentifier else { return }
         // Move to the end of previous line if exists.
         self.textDocumentProxy.adjustTextPosition(byCharacterOffset: -1)
         // Must have a delay, otherwise previousLineLength may always be 0.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          guard self.currentDocumentIdentifier() == documentIdentifier else { return }
           let textBefore = lastLine(self.textDocumentProxy.documentContextBeforeInput ?? "")
           if textBefore.count > offset {
             self.textDocumentProxy.adjustTextPosition(
@@ -340,15 +376,15 @@ class KeyboardViewController: UIInputViewController, FcitxProtocol {
   }
 
   public func resetInput() {
-    Fcitx.resetInput()
+    Fcitx.resetInput(program, currentDocumentIdentifier())
   }
 
   public func triggerUnicode() {
-    Fcitx.triggerUnicode()
+    Fcitx.triggerUnicode(program, currentDocumentIdentifier())
   }
 
   public func triggerQuickPhrase() {
-    Fcitx.triggerQuickPhrase()
+    Fcitx.triggerQuickPhrase(program, currentDocumentIdentifier())
   }
 
   public func commitString(_ commit: String) {

--- a/protocol/FcitxProtocol.swift
+++ b/protocol/FcitxProtocol.swift
@@ -1,5 +1,6 @@
 @MainActor
-public protocol FcitxProtocol {
+public protocol FcitxProtocol: AnyObject {
+  func isCurrentDocument(_ program: String, _ documentIdentifier: String) -> Bool
   func keyPressed(_ key: String, _ code: String, _ modifiers: UInt32)
   func forwardKey(_ key: String, _ code: String)
   func carriageReturn()

--- a/uipanel/CandidateBar.swift
+++ b/uipanel/CandidateBar.swift
@@ -37,6 +37,8 @@ struct CandidateBarView: View {
   let preedit: String
   let caret: Int
   let candidates: [String]
+  let program: String
+  let documentIdentifier: String
   let highlighted: Int
   let rowItemCount: [Int]
   let tabActions: [CandidateAction]
@@ -77,7 +79,7 @@ struct CandidateBarView: View {
   private func loadMoreCandidates(_ start: Int, _ count: Int) {
     if pendingScroll < start {
       pendingScroll = start
-      scroll(Int32(start), Int32(count))
+      scroll(program, documentIdentifier, Int32(start), Int32(count))
     }
   }
 

--- a/uipanel/VirtualKeyboard.swift
+++ b/uipanel/VirtualKeyboard.swift
@@ -14,7 +14,7 @@ public enum DisplayMode {
 }
 
 @MainActor
-var client: FcitxProtocol!
+weak var client: FcitxProtocol!
 
 @MainActor
 public func setClient(_ cli: FcitxProtocol) {

--- a/uipanel/VirtualKeyboard.swift
+++ b/uipanel/VirtualKeyboard.swift
@@ -58,6 +58,8 @@ public class ViewModel: ObservableObject {
   // Have requested load more candidates starting from this index. -1 means not scrollable.
   @Published var pendingScroll = 0
   @Published var tabActions = [CandidateAction]()
+  @Published var inputContextProgram = ""
+  @Published var inputContextDocumentIdentifier = ""
 
   @Published var actions = [StatusAreaAction]()
   @Published var inputMethods = [InputMethod]()
@@ -106,7 +108,8 @@ public class ViewModel: ObservableObject {
   }
 
   func setCandidates(
-    _ auxUp: String, _ preedit: String, _ caret: Int32, _ candidates: [String],
+    _ program: String, _ documentIdentifier: String, _ auxUp: String, _ preedit: String,
+    _ caret: Int32, _ candidates: [String],
     _ highlighted: Int32, _ bulk: Bool, _ hasClientPreedit: Bool, _ tabActions: [CandidateAction],
     _ hasPrev: Bool, _ hasNext: Bool, _ endReached: Bool
   ) {
@@ -127,6 +130,8 @@ public class ViewModel: ObservableObject {
     self.highlighted = Int(highlighted)
     self.hasClientPreedit = hasClientPreedit
     self.tabActions = tabActions
+    inputContextProgram = program
+    inputContextDocumentIdentifier = documentIdentifier
     batch = (batch + 1) & 0xFFFF
     scrollEnd = endReached
     self.hasPrev = hasPrev
@@ -137,7 +142,7 @@ public class ViewModel: ObservableObject {
   }
 
   public func clearInputPanel() {
-    setCandidates("", "", 0, [], -1, false, false, [], false, false, false)
+    setCandidates("", "", "", "", 0, [], -1, false, false, [], false, false, false)
   }
 
   func scroll(_ candidates: [String], _ end: Bool) {
@@ -342,6 +347,8 @@ public struct VirtualKeyboardView: View {
               CandidateBarView(
                 width: width, auxUp: viewModel.auxUp, preedit: viewModel.preedit,
                 caret: viewModel.caret, candidates: viewModel.candidates,
+                program: viewModel.inputContextProgram,
+                documentIdentifier: viewModel.inputContextDocumentIdentifier,
                 highlighted: viewModel.highlighted,
                 rowItemCount: viewModel.rowItemCount,
                 tabActions: viewModel.tabActions,

--- a/uipanel/VirtualKeyboard.swift
+++ b/uipanel/VirtualKeyboard.swift
@@ -136,6 +136,10 @@ public class ViewModel: ObservableObject {
     pendingScroll = bulk ? 0 : -1
   }
 
+  public func clearInputPanel() {
+    setCandidates("", "", 0, [], -1, false, false, [], false, false, false)
+  }
+
   func scroll(_ candidates: [String], _ end: Bool) {
     self.candidates.append(contentsOf: candidates)
     rowItemCount = calculateLayout(

--- a/uipanel/keyboardui.swift
+++ b/uipanel/keyboardui.swift
@@ -12,7 +12,8 @@ public func setCandidatesAsync(
   DispatchQueue.main.async {
     guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     vm.setCandidates(
-      auxUp, preedit, caret, candidates, highlighted, bulk, hasClientPreedit,
+      program, documentIdentifier, auxUp, preedit, caret, candidates, highlighted, bulk,
+      hasClientPreedit,
       deserialize([CandidateAction].self, tabActionsJSON), hasPrev, hasNext, endReached)
   }
 }

--- a/uipanel/keyboardui.swift
+++ b/uipanel/keyboardui.swift
@@ -4,19 +4,24 @@ import SwiftUI
 import SwiftUtil
 
 public func setCandidatesAsync(
-  _ auxUp: String, _ preedit: String, _ caret: Int32, _ candidates: [String],
+  _ program: String, _ documentIdentifier: String, _ auxUp: String, _ preedit: String,
+  _ caret: Int32, _ candidates: [String],
   _ highlighted: Int32, _ bulk: Bool, _ hasClientPreedit: Bool, _ tabActionsJSON: String,
   _ hasPrev: Bool, _ hasNext: Bool, _ endReached: Bool
 ) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     vm.setCandidates(
       auxUp, preedit, caret, candidates, highlighted, bulk, hasClientPreedit,
       deserialize([CandidateAction].self, tabActionsJSON), hasPrev, hasNext, endReached)
   }
 }
 
-public func scrollAsync(_ candidates: [String], _ end: Bool) {
+public func scrollAsync(
+  _ program: String, _ documentIdentifier: String, _ candidates: [String], _ end: Bool
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     vm.scroll(candidates, end)
   }
 }
@@ -42,14 +47,20 @@ public struct StatusAreaAction: Identifiable, Sendable {
   }
 }
 
-public func setStatusAreaAsync(_ actions: [StatusAreaAction]) {
+public func setStatusAreaAsync(
+  _ program: String, _ documentIdentifier: String, _ actions: [StatusAreaAction]
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     vm.setStatusArea(actions)
   }
 }
 
-public func setCurrentInputMethodAsync(_ im: String) {
+public func setCurrentInputMethodAsync(
+  _ program: String, _ documentIdentifier: String, _ im: String
+) {
   DispatchQueue.main.async {
+    guard let client, client.isCurrentDocument(program, documentIdentifier) else { return }
     vm.setCurrentInputMethod(
       im, deserialize([InputMethod].self, String(getInputMethods())))
   }

--- a/uipanel/uipanel-public.h
+++ b/uipanel/uipanel-public.h
@@ -7,5 +7,6 @@ void activateCandidateAction(int index, int id);
 void activateCandidateTabAction(int id);
 void selectCandidate(int index);
 void activateStatusAreaAction(int id);
-void scroll(int start, int count);
+void scroll(const char *program, const char *documentIdentifier, int start,
+            int count);
 void page(bool next);

--- a/uipanel/uipanel.cpp
+++ b/uipanel/uipanel.cpp
@@ -20,13 +20,23 @@ UIPanel::UIPanel(Instance *instance) : instance_(instance) {
     eventHandler_ = instance_->watchEvent(
         EventType::InputContextInputMethodActivated, EventWatcherPhase::Default,
         [this](Event &event) {
+            auto &icEvent = static_cast<InputContextEvent &>(event);
+            auto *ic = dynamic_cast<IosInputContext *>(icEvent.inputContext());
+            if (!ic) {
+                return;
+            }
             auto im = instance_->currentInputMethod();
-            KeyboardUI::setCurrentInputMethodAsync(im.c_str());
+            KeyboardUI::setCurrentInputMethodAsync(
+                ic->program(), ic->documentIdentifier(), im);
         });
 }
 
 void UIPanel::update(UserInterfaceComponent component,
                      InputContext *inputContext) {
+    auto *ic = dynamic_cast<IosInputContext *>(inputContext);
+    if (!ic) {
+        return;
+    }
     switch (component) {
     case UserInterfaceComponent::InputPanel: {
         const InputPanel &inputPanel = inputContext->inputPanel();
@@ -48,7 +58,8 @@ void UIPanel::update(UserInterfaceComponent component,
         if (const auto &list = inputPanel.candidateList()) {
             const auto &bulk = list->toBulk();
             if (bulk) {
-                return expand(auxUp, preedit, caret, hasClientPreedit, list);
+                return expand(*ic, auxUp, preedit, caret, hasClientPreedit,
+                              list);
             }
             size = list->size();
             for (int i = 0; i < size; i++) {
@@ -66,23 +77,24 @@ void UIPanel::update(UserInterfaceComponent component,
                 hasNext = pageable->hasNext();
             }
         }
-        KeyboardUI::setCandidatesAsync(auxUp, preedit, caret, candidates,
+        KeyboardUI::setCandidatesAsync(ic->program(), ic->documentIdentifier(),
+                                       auxUp, preedit, caret, candidates,
                                        highlighted, false, hasClientPreedit,
                                        "[]", hasPrev, hasNext, false);
         break;
     }
     case UserInterfaceComponent::StatusArea:
-        updateStatusArea(inputContext);
+        updateStatusArea(*ic);
         break;
     }
 }
 
-swift::Array<swift::String> getBulkCandidates(Instance *instance, int start,
+swift::Array<swift::String> getBulkCandidates(Instance *instance,
+                                              IosInputContext &ic, int start,
                                               int count,
                                               bool *pEndReached = nullptr) {
     auto candidates = swift::Array<swift::String>::init();
-    auto ic = instance->mostRecentInputContext();
-    const auto &list = ic->inputPanel().candidateList();
+    const auto &list = ic.inputPanel().candidateList();
     if (!list) {
         return candidates;
     }
@@ -98,7 +110,7 @@ swift::Array<swift::String> getBulkCandidates(Instance *instance, int start,
         try {
             auto &candidate = bulk->candidateFromAll(i);
             candidates.append(
-                instance->outputFilter(ic, candidate.text()).toString());
+                instance->outputFilter(&ic, candidate.text()).toString());
         } catch (const std::invalid_argument &e) {
             // size == -1 but actual limit is reached
             endReached = true;
@@ -129,22 +141,31 @@ static std::string serializeTabActions(TabbedCandidateList *tabbedList) {
     return j.dump();
 }
 
-void UIPanel::expand(const std::string &auxUp, const std::string &preedit,
-                     int caret, bool hasClientPreedit,
+void UIPanel::expand(IosInputContext &ic, const std::string &auxUp,
+                     const std::string &preedit, int caret,
+                     bool hasClientPreedit,
                      std::shared_ptr<CandidateList> list) {
     bool endReached = false;
-    auto candidates = getBulkCandidates(instance_, 0, 72,
+    auto candidates = getBulkCandidates(instance_, ic, 0, 72,
                                         &endReached); // Vertically 2 screens.
     auto tabActions = serializeTabActions(list->toTabbed());
-    KeyboardUI::setCandidatesAsync(auxUp, preedit, caret, candidates, 0, true,
+    KeyboardUI::setCandidatesAsync(ic.program(), ic.documentIdentifier(), auxUp,
+                                   preedit, caret, candidates, 0, true,
                                    hasClientPreedit, tabActions, false, false,
                                    endReached);
 }
 
 void UIPanel::scroll(int start, int count) {
+    auto *ic =
+        dynamic_cast<IosInputContext *>(instance_->mostRecentInputContext());
+    if (!ic) {
+        return;
+    }
     bool endReached = false;
-    auto candidates = getBulkCandidates(instance_, start, count, &endReached);
-    KeyboardUI::scrollAsync(candidates, endReached);
+    auto candidates =
+        getBulkCandidates(instance_, *ic, start, count, &endReached);
+    KeyboardUI::scrollAsync(ic->program(), ic->documentIdentifier(), candidates,
+                            endReached);
 }
 
 void UIPanel::page(bool next) {
@@ -172,17 +193,18 @@ KeyboardUI::StatusAreaAction convertAction(Action *action, InputContext *ic) {
         action->isChecked(ic), action->isSeparator(), children);
 }
 
-void UIPanel::updateStatusArea(InputContext *ic) {
+void UIPanel::updateStatusArea(IosInputContext &ic) {
     auto actions = swift::Array<KeyboardUI::StatusAreaAction>::init();
-    auto &statusArea = ic->statusArea();
+    auto &statusArea = ic.statusArea();
     for (auto *action : statusArea.allActions()) {
         if (!action->id()) {
             // Not registered with UI manager.
             continue;
         }
-        actions.append(convertAction(action, ic));
+        actions.append(convertAction(action, &ic));
     }
-    KeyboardUI::setStatusAreaAsync(actions);
+    KeyboardUI::setStatusAreaAsync(ic.program(), ic.documentIdentifier(),
+                                   actions);
 }
 
 } // namespace fcitx

--- a/uipanel/uipanel.cpp
+++ b/uipanel/uipanel.cpp
@@ -155,9 +155,16 @@ void UIPanel::expand(IosInputContext &ic, const std::string &auxUp,
                                    endReached);
 }
 
-void UIPanel::scroll(int start, int count) {
-    auto *ic =
-        dynamic_cast<IosInputContext *>(instance_->mostRecentInputContext());
+void UIPanel::scroll(const std::string &program,
+                     const std::string &documentIdentifier, int start,
+                     int count) {
+    auto *frontend = dynamic_cast<IosFrontend *>(
+        instance_->addonManager().addon("iosfrontend"));
+    if (!frontend) {
+        return;
+    }
+    auto *ic = dynamic_cast<IosInputContext *>(
+        frontend->inputContext(program, documentIdentifier));
     if (!ic) {
         return;
     }
@@ -211,8 +218,10 @@ void UIPanel::updateStatusArea(IosInputContext &ic) {
 
 FCITX_ADDON_FACTORY_V2(uipanel, fcitx::UIPanelFactory);
 
-void scroll(int start, int count) {
-    dispatcher->schedule([start, count] { fcitx::ui->scroll(start, count); });
+void scroll(const char *p, const char *d, int start, int count) {
+    std::string program = p, documentIdentifier = d;
+    dispatcher->schedule(
+        [=] { fcitx::ui->scroll(program, documentIdentifier, start, count); });
 }
 
 void page(bool next) {

--- a/uipanel/uipanel.h
+++ b/uipanel/uipanel.h
@@ -8,6 +8,8 @@
 
 namespace fcitx {
 
+class IosInputContext;
+
 class UIPanel final : public VirtualKeyboardUserInterface {
   public:
     UIPanel(Instance *);
@@ -36,9 +38,10 @@ class UIPanel final : public VirtualKeyboardUserInterface {
     Instance *instance_;
     std::unique_ptr<HandlerTableEntry<EventHandler>> eventHandler_;
 
-    void updateStatusArea(InputContext *ic);
-    void expand(const std::string &auxUp, const std::string &preedit, int caret,
-                bool hasClientPreedit, std::shared_ptr<CandidateList> list);
+    void updateStatusArea(IosInputContext &ic);
+    void expand(IosInputContext &ic, const std::string &auxUp,
+                const std::string &preedit, int caret, bool hasClientPreedit,
+                std::shared_ptr<CandidateList> list);
 };
 
 class UIPanelFactory : public AddonFactory {

--- a/uipanel/uipanel.h
+++ b/uipanel/uipanel.h
@@ -31,7 +31,8 @@ class UIPanel final : public VirtualKeyboardUserInterface {
     bool isVirtualKeyboardVisible() const override { return true; }
     void showVirtualKeyboard() override {}
     void hideVirtualKeyboard() override {}
-    void scroll(int start, int count);
+    void scroll(const std::string &program,
+                const std::string &documentIdentifier, int start, int count);
     void page(bool next);
 
   private:


### PR DESCRIPTION
KeyboardViewController's id is treated as program, which represent a keyboard display. documentIdentifier is treated as InputContext, which represent a one-time text field focus.

Addresses https://github.com/fcitx-contrib/fcitx5-ios/pull/123#discussion_r3938060083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Supports multiple simultaneous input contexts identified by application and document.
  - Provides explicit cleanup when a document or application closes.
  - Routes keyboard actions and UI updates to the correct document.
  - Allows the candidate and input panel to be cleared.

- **Bug Fixes**
  - Prevents delayed callbacks from affecting stale or replaced documents.
  - Improves handling when the keyboard controller or client is unavailable.
  - Preserves focus, navigation, candidate, and input-method updates across document changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->