### PR TITLE
fix KeyboardViewController change requires configure; fix reconfigure triggers mass build

### DIFF
--- a/patches/fcitx5.patch
+++ b/patches/fcitx5.patch
@@ -1,3 +1,16 @@
+diff --git a/src/lib/fcitx-utils/Fcitx5Macros.cmake b/src/lib/fcitx-utils/Fcitx5Macros.cmake
+index 9c94dee1..d4175f43 100644
+--- a/src/lib/fcitx-utils/Fcitx5Macros.cmake
++++ b/src/lib/fcitx-utils/Fcitx5Macros.cmake
+@@ -22,7 +22,7 @@ function(fcitx5_import_addons target)
+ 
+   foreach(addon IN LISTS FCITX5_IMPORT_ADDONS)
+       set(filename "${CMAKE_CURRENT_BINARY_DIR}/${target}-${addon}-import-addon.cpp")
+-      file(WRITE "${filename}" "
++      file(CONFIGURE OUTPUT "${filename}" CONTENT "
+ #include <fcitx/addonloader.h>
+ extern fcitx::StaticAddonRegistry &${FCITX5_IMPORT_REGISTRY_VARNAME}();
+ FCITX_IMPORT_ADDON_FACTORY(${FCITX5_IMPORT_REGISTRY_VARNAME}, ${addon});
 diff --git a/src/lib/fcitx-utils/log.cpp b/src/lib/fcitx-utils/log.cpp
 index 56fb7f62..98fa2ae6 100644
 --- a/src/lib/fcitx-utils/log.cpp

--- a/patches/ios-cmake.patch
+++ b/patches/ios-cmake.patch
@@ -1,0 +1,30 @@
+diff --git a/ios.toolchain.cmake b/ios.toolchain.cmake
+index 3d008f8..a9f54fb 100644
+--- a/ios.toolchain.cmake
++++ b/ios.toolchain.cmake
+@@ -980,7 +980,7 @@ endif()
+ #Check if Xcode generator is used since that will handle these flags automagically
+ if(CMAKE_GENERATOR MATCHES "Xcode")
+   message(STATUS "Not setting any manual command-line buildflags, since Xcode is selected as the generator. Modifying the Xcode build-settings directly instead.")
+-else()
++elseif(NOT IOS_CMAKE_MANUAL_FLAGS_INITIALIZED)
+   set(CMAKE_C_FLAGS "${C_TARGET_FLAGS} ${APPLE_TARGET_TRIPLE_FLAG} ${SDK_NAME_VERSION_FLAGS} ${OBJC_LEGACY_VARS} ${BITCODE} ${VISIBILITY} ${CMAKE_C_FLAGS}" CACHE INTERNAL
+      "Flags used by the compiler during all C build types.")
+   set(CMAKE_C_FLAGS_DEBUG "-O0 -g ${CMAKE_C_FLAGS_DEBUG}")
+@@ -1019,6 +1019,8 @@ else()
+   endif()
+   set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp" CACHE INTERNAL
+      "Flags used by the compiler for all ASM build types.")
++  set(IOS_CMAKE_MANUAL_FLAGS_INITIALIZED TRUE CACHE INTERNAL
++     "Whether ios-cmake's manual command-line build flags were initialized.")
+ endif()
+ 
+ ## Print status messages to inform of the current state
+@@ -1103,6 +1105,7 @@ set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+         CMAKE_C_LINK_FLAGS
+         CMAKE_CXX_LINK_FLAGS
+         CMAKE_ASM_FLAGS
++        IOS_CMAKE_MANUAL_FLAGS_INITIALIZED
+ )
+ 
+ if(NAMED_LANGUAGE_SUPPORT_INT)

--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -19,3 +19,4 @@ apply_patch deps/ZIPFoundation patches/ZIPFoundation.patch
 apply_patch engines/libime/src/libime/core/kenlm patches/kenlm.patch
 apply_patch engines/fcitx5-hallelujah patches/hallelujah.patch
 apply_patch engines/fcitx5-rime patches/rime.patch
+apply_patch ios-cmake patches/ios-cmake.patch

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,8 +171,14 @@ add_dependencies(${BUNDLE_NAME} ${EXTENSIONS})
 foreach(Keyboard ${KEYBOARDS})
     # Ninja generator wrongly creates .app instead of .appex so symlink for now.
     execute_process(COMMAND ln -sfh "${Keyboard}.app" "${CMAKE_CURRENT_BINARY_DIR}/${Keyboard}.appex")
-    # Embed keyboard.appex in app.
-    copy_to(app copy_directory "${CMAKE_CURRENT_BINARY_DIR}/${Keyboard}.appex" "PlugIns/${Keyboard}.appex")
+    # Embed keyboard.appex in app whenever the extension itself is linked.
+    add_custom_command(TARGET ${Keyboard}Extension POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            "$<TARGET_BUNDLE_DIR:${BUNDLE_NAME}>/PlugIns"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_BINARY_DIR}/${Keyboard}.appex"
+            "$<TARGET_BUNDLE_DIR:${BUNDLE_NAME}>/PlugIns/${Keyboard}.appex"
+    )
 endforeach()
 
 # Settings bundle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,21 +164,22 @@ target_link_libraries(${BUNDLE_NAME}
     ZIPFoundation
 )
 
-list(TRANSFORM KEYBOARDS APPEND "Extension" OUTPUT_VARIABLE EXTENSIONS)
-# Make main app the last target so that keyboard can be copied into it.
-add_dependencies(${BUNDLE_NAME} ${EXTENSIONS})
-
 foreach(Keyboard ${KEYBOARDS})
     # Ninja generator wrongly creates .app instead of .appex so symlink for now.
     execute_process(COMMAND ln -sfh "${Keyboard}.app" "${CMAKE_CURRENT_BINARY_DIR}/${Keyboard}.appex")
-    # Embed keyboard.appex in app whenever the extension itself is linked.
-    add_custom_command(TARGET ${Keyboard}Extension POST_BUILD
+    set(embedded_appex "$<TARGET_BUNDLE_DIR:${BUNDLE_NAME}>/PlugIns/${Keyboard}.appex")
+    set(embedded_binary "${CMAKE_CURRENT_BINARY_DIR}/${BUNDLE_NAME}.app/PlugIns/${Keyboard}.appex/${Keyboard}")
+    add_custom_command(OUTPUT "${embedded_binary}"
         COMMAND ${CMAKE_COMMAND} -E make_directory
             "$<TARGET_BUNDLE_DIR:${BUNDLE_NAME}>/PlugIns"
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             "${CMAKE_CURRENT_BINARY_DIR}/${Keyboard}.appex"
-            "$<TARGET_BUNDLE_DIR:${BUNDLE_NAME}>/PlugIns/${Keyboard}.appex"
+            "${embedded_appex}"
+        DEPENDS ${Keyboard}Extension
+        COMMENT "Embedding ${Keyboard}.appex"
     )
+    add_custom_target(${Keyboard}EmbeddedExtension DEPENDS "${embedded_binary}")
+    add_dependencies(${BUNDLE_NAME} ${Keyboard}EmbeddedExtension)
 endforeach()
 
 # Settings bundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS builds by preventing duplicate compiler flag initialization.
  * Improved keyboard extension packaging during app builds.
  * Prevented unintended input method settings from being cleared in keyboard environments.
  * Updated logging and add-on loading behavior for greater runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->